### PR TITLE
[HC-188] 강의 리뷰에서 강의 목록으로 뒤로가기 시 스크롤 위치 기억 기능 구현

### DIFF
--- a/src/pages/CourseList/CourseList.tsx
+++ b/src/pages/CourseList/CourseList.tsx
@@ -61,7 +61,7 @@ export default function CourseList() {
     setMajorOpen(false); // 강의 목록 버튼 누르면 전공별 분류 숨김
     setSelectedMajor("专业");
     setSelectedCategory(category);
-    setShowYouguan(false); 
+    setShowYouguan(false);
   };
 
   const handleShowYouguan = () => {
@@ -70,19 +70,31 @@ export default function CourseList() {
     setShowYouguan(true);
   };
 
+  // 리뷰에서 뒤로가기로 돌아올 시 스크롤 위치 기억
+  const handleScrolling = () => {
+    const navigatedToReview = sessionStorage.getItem("navigatedToReview");
+    if (navigatedToReview) {
+      setTimeout(() => {
+        window.scrollTo({
+          top: parseInt(sessionStorage.courseListScrollY),
+          left: 0,
+          behavior: "instant",
+        });
+        sessionStorage.removeItem("navigatedToReview");
+      }, 0);
+    }
+  };
+
   useEffect(() => {
     const fetchDataFromApi = async () => {
       try {
         setIsLoading(true);
         const response = await apiGet(`/courses`);
-        console.log(response.data);
         setCourses(response.data);
         setIsLoading(false);
-        window.scrollTo(0, 0);
+        handleScrolling();
       } catch (error) {
-        console.error(error);
         setIsLoading(false);
-        window.scrollTo(0, 0);
       }
     };
     fetchDataFromApi();
@@ -101,7 +113,11 @@ export default function CourseList() {
         );
 
   return (
-    <div>
+    <div
+      onClick={() =>
+        sessionStorage.setItem("courseListScrollY", window.scrollY.toString())
+      }
+    >
       <PageView isLoading={isLoading}>
         <Container
           fluid
@@ -170,14 +186,14 @@ export default function CourseList() {
                 {/* 카테고리별 수업 분류 */}
                 <div className={styles.groupReviews}>
                   {filteredCourses.map((course) => (
-                    <CourseCard course={course} />
+                    <CourseCard key={course.course_id} course={course} />
                   ))}
                 </div>
 
                 {/* 전공별 수업 분류 */}
                 <div className={styles.majorGroupReviews}>
                   {filterdMajors.map((course) => (
-                    <CourseCard course={course} />
+                    <CourseCard key={course.course_id} course={course} />
                   ))}
                 </div>
               </div>

--- a/src/pages/CourseList/components/CourseCard/CourseCard.tsx
+++ b/src/pages/CourseList/components/CourseCard/CourseCard.tsx
@@ -13,7 +13,7 @@ export default function CourseCard({ course }: CourseCardProps) {
       to={`/courses/view/${course.course_id}`}
       key={course.course_id}
       className="list-group-item list-group-item-action"
-      target="_blank"
+      onClick={() => sessionStorage.setItem("navigatedToReview", "true")}
     >
       <div className="d-flex justify-content-between align-items-center">
         <h5 className={styles.courseSet}>

--- a/src/pages/PageView/PageView.css
+++ b/src/pages/PageView/PageView.css
@@ -1,6 +1,0 @@
-.body{
-    min-height: calc(100vh - 70px);
-    margin-top: 100px;
-    margin-bottom: 50px;
-    background-color: white;
-}

--- a/src/pages/PageView/PageView.tsx
+++ b/src/pages/PageView/PageView.tsx
@@ -1,6 +1,4 @@
-import "./PageView.css";
 import React from "react";
-import { useEffect } from "react";
 import { Spinner, Container } from "react-bootstrap";
 
 type PageViewProps = {
@@ -14,20 +12,16 @@ export default function PageView({
   paddingBottom = 0,
   isLoading = false,
 }: PageViewProps) {
-  useEffect(() => {
-    // 맨 위로 페이지 스크롤 올리기
-    window.scrollTo(0, 0);
-  }, []);
-
-  const style = {
-    minHeight: `calc(100vh - 70px)`,
-    display: "flex",
-    marginTop: "90px",
-    paddingBottom: paddingBottom,
-  };
 
   return (
-    <div className="body" style={style}>
+    <div
+      style={{
+        minHeight: `calc(100vh - 70px)`,
+        display: "flex",
+        marginTop: "90px",
+        paddingBottom: paddingBottom,
+      }}
+    >
       {isLoading ? ( // isLoading일 시 로딩 아이콘 표시
         <Container fluid className="d-flex justify-content-center">
           <Spinner className="my-auto" animation="border" role="status">


### PR DESCRIPTION
## 강의 리뷰에서 강의 목록으로 뒤로가기 시 스크롤 위치 기억 기능 구현
구현 과정:
```jsx
<div onClick={() =>sessionStorage.setItem("courseListScrollY", window.scrollY.toString())}>

<Link
   ...
   onClick={() => sessionStorage.setItem("navigatedToReview", "true")} />
```

우선 CourseList의 최상위 div에서 클릭 이벤트 발생 시 (즉 클릭해서 리뷰를 보러 가는 이벤트) sessionStorage에 `courseListScrollY` 이름으로 현재 스크롤 위치 저장, 동시에 강의 링크가 클릭 될 시 CourseList에서 해당 강의 페이지로 이동했다는것을 저장해두기 위해 `onClick`으로 `navigatedToReview`에 `true` 저장

```jsx
// 리뷰에서 뒤로가기로 돌아올 시 스크롤 위치 기억
  const handleScrolling = () => {
    const navigatedToReview = sessionStorage.getItem("navigatedToReview");
    if (navigatedToReview) {
      setTimeout(() => {
        window.scrollTo({
          top: parseInt(sessionStorage.courseListScrollY),
          left: 0,
          behavior: "instant",
        });
        sessionStorage.removeItem("navigatedToReview");
      }, 0);
    }
  };
```
이후 CourseList의 useEffect에서 `navigatedToReview`값이 `true`인지 확인 (링크 눌렀다가 돌아온건지), 이후 맞다면 저장되어 있는 스크롤 위치로 즉시 이동. 이후 navigatedToReview 삭제.


react-router-dom v6부턴 history 사용이 불가해서 전 페이지가 어떤 페이지었는지 주소를 얻는게 불가능해 좀 복잡하게 구현됨.